### PR TITLE
Feat/154392633/redesign user interface

### DIFF
--- a/client/src/components/recipe/addRecipe/RecipePage.jsx
+++ b/client/src/components/recipe/addRecipe/RecipePage.jsx
@@ -14,6 +14,7 @@ import '../../../styles/recipes.scss';
 import Recipe from './recipe';
 import AddRecipeModal from '../../Modal/AddRecipeModal';
 import Footer from '../../common/Footer';
+/* eslint-disable */
 
 /**
  *

--- a/client/src/components/recipe/addRecipe/recipe.jsx
+++ b/client/src/components/recipe/addRecipe/recipe.jsx
@@ -1,7 +1,10 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
+import toastr from 'toastr';
+import { confirmAlert } from 'react-confirm-alert';
+import 'react-confirm-alert/src/react-confirm-alert.css';
 import EditRecipeModal from '../../Modal/EditRecipeModal';
-
+/* eslint-disable */
 
 class Recipe extends Component {
   constructor(props) {
@@ -10,11 +13,20 @@ class Recipe extends Component {
 
     this.state = {
       modal: false,
+      showDialog: false,
     };
     this.toggle = this.toggle.bind(this);
   }
+
   onDelete() {
-    this.props.deleteRecipe(this.props.recipe.id);
+    confirmAlert({
+      title: 'Delete this recipe',
+      message: 'Are you sure to do this?',
+      confirmLabel: 'Confirm',
+      cancelLabel: 'Cancel',
+      onConfirm: () => this.props.deleteRecipe(this.props.recipe.id),
+      onCancel: () => toastr.success('Good choice!')
+    })
   }
 
   toggle() {

--- a/client/src/components/recipe/addRecipe/recipe.jsx
+++ b/client/src/components/recipe/addRecipe/recipe.jsx
@@ -21,7 +21,7 @@ class Recipe extends Component {
   onDelete() {
     confirmAlert({
       title: 'Delete this recipe',
-      message: 'Are you sure to do this?',
+      message: 'Are you sure you want to do this?',
       confirmLabel: 'Confirm',
       cancelLabel: 'Cancel',
       onConfirm: () => this.props.deleteRecipe(this.props.recipe.id),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11588,6 +11588,11 @@
         "warning": "3.0.0"
       }
     },
+    "react-confirm-alert": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-1.0.8.tgz",
+      "integrity": "sha1-E8u889mSokWzFe8YzCA4JVbj8DM="
+    },
     "react-deep-force-update": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-bootstrap": "^0.31.5",
+    "react-confirm-alert": "^1.0.8",
     "react-dom": "^16.0.0",
     "react-dropzone": "^4.2.1",
     "react-hot-loader": "^3.0.0",


### PR DESCRIPTION
#### What does this PR do?
allows the user to select whether he or she wants to delete using a modal
#### Description of Task to be completed?
 * install `react-confirm-alert`
* add it to the delete function on the recipe page component
#### How should this be manually tested?
Have the app working by:
* clone the git repository and follow the installation procedure on the readMe
 * run the command `npm runs start:dev` on the command line to start the server
 * once app is running, navigate to the app using `localhost:3000/recipes` after signing in
 * click on the delete icon

 #### Any background context you want to provide?
 Nil
 #### What are the relevant pivotal tracker stories?
#154392633
 #### Screenshots (if appropriate)
  
<img width="1429" alt="screen shot 2018-01-17 at 11 22 33 am" src="https://user-images.githubusercontent.com/26750279/35037806-e1f01d58-fb78-11e7-949b-8b42806fb9cf.png">
